### PR TITLE
Specify the Shadow version to avoid failure in the building

### DIFF
--- a/src/build.gradle
+++ b/src/build.gradle
@@ -23,7 +23,7 @@
 buildscript {
     repositories { maven { url 'https://plugins.gradle.org/m2/' } }
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:+'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:1.2'
     }
 }


### PR DESCRIPTION
The newest Shadow may lead to some failure in the building. Specify the version will solve that problem.